### PR TITLE
Respect PASSWORD_STORE_DIR env variable if it's set

### DIFF
--- a/upass/__main__.py
+++ b/upass/__main__.py
@@ -171,7 +171,7 @@ class App(object):
         self.box = FancyListBox(urwid.SimpleFocusListWalker(listbox_content))
         self.box._app = self
 
-        self.home = os.path.expanduser('~/.password-store')
+        self.home = os.environ.get('PASSWORD_STORE_DIR', os.path.expanduser('~/.password-store'))
         if os.path.exists(self.home) and os.listdir(self.home):
             self.refresh()
             self.current = '.'


### PR DESCRIPTION
pass itself uses the directory specified in `PASSWORD_STORE_DIR`, rather than the directory `~/.password-store`, if the environment variable is set. upass should do the same, and this commit produces that effect.

For an example of usage: on my system I have set `PASSWORD_STORE_DIR` to `$XDG_DATA_HOME/pass`, which keeps my password store tucked away in `XDG_DATA_HOME` and avoids producing yet another dotfile in my home directory.