### PR TITLE
Added support for custom pass command

### DIFF
--- a/README
+++ b/README
@@ -29,7 +29,13 @@ CONFIGURATION
 upass stores its config in ``~/.config/kwpolska/upass/upass.ini`` (but it
 respects ``XDG_CONFIG_HOME`` if you changed it). Available options:
 
+* general - general configuration.
+
+  * command — set the command that implementst the ``pass`` API (Default:
+    ``pass``). This adds support for commands such as ``gopass``.
+
 * keys — keybinding configuration.
+
   * help, display, copy, refresh, search, quit — set key bindings for commands,
     space-separated (eg. ``quit=q f10`` will make ``q`` and ``f10`` keybindings
     for ``quit``)

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -29,7 +29,13 @@ CONFIGURATION
 upass stores its config in ``~/.config/kwpolska/upass/upass.ini`` (but it
 respects ``XDG_CONFIG_HOME`` if you changed it). Available options:
 
+* general - general configuration.
+
+  * command — set the command that implementst the ``pass`` API (Default:
+    ``pass``). This adds support for commands such as ``gopass``.
+
 * keys — keybinding configuration.
+
   * help, display, copy, refresh, search, quit — set key bindings for commands,
     space-separated (eg. ``quit=q f10`` will make ``q`` and ``f10`` keybindings
     for ``quit``)

--- a/upass/__main__.py
+++ b/upass/__main__.py
@@ -208,6 +208,9 @@ class App(object):
 
         self.footer = urwid.Columns(column_data)
 
+        # Load pass command from ini file
+        self.command = upass.config['general'].get('command', 'pass')
+
         # Load keys from ini file
         ini_commands = {
             'display': self.display_selected,
@@ -334,7 +337,7 @@ class App(object):
                          'Please select the option to overwrite the existing password to generate a new password '
                          'for this entry.'.format(path))
         else:
-            gargs = ['pass', 'generate']
+            gargs = [self.command, 'generate']
             if not symbols:
                 gargs.append('-n')
             if force:
@@ -488,7 +491,7 @@ class App(object):
         """Call pass to get a password."""
         self.current, copy, copy_key = args
         self.set_header(self.current)
-        pargs = ['pass', self.current]
+        pargs = [self.command, self.current]
         copymsg = ' and copying output afterwards' if copy else ''
         self.mode = 'call_pass'
         self._clear_box()

--- a/upass/data/upass.ini.skel
+++ b/upass/data/upass.ini.skel
@@ -1,3 +1,6 @@
+[general]
+command=pass
+
 [keys]
 help=? h
 display=d s


### PR DESCRIPTION
This adds support to use a backing engine such as `gopass` (https://github.com/gopasspw/gopass) which fully supports the `pass` API.