### PR TITLE
Add XDG_BASE_DIR support

### DIFF
--- a/upass/__main__.py
+++ b/upass/__main__.py
@@ -186,10 +186,10 @@ class App(object):
         self.box = FancyListBox(urwid.SimpleFocusListWalker(listbox_content))
         self.box._app = self
 
-        self.home = os.environ.get('PASSWORD_STORE_DIR', os.path.expanduser('~/.password-store'))
+        self.home = os.path.expanduser(os.environ.get('PASSWORD_STORE_DIR', '~/.password-store'))
         if not os.path.exists(self.home):
-            self.home = os.path.join(os.environ.get(
-                'XDG_DATA_HOME', '~/.local/share'), 'password-store')
+            self.home = os.path.expanduser(os.path.join(os.environ.get(
+                'XDG_DATA_HOME', '~/.local/share'), 'password-store'))
 
         if os.path.exists(self.home) and os.listdir(self.home):
             self.refresh()

--- a/upass/__main__.py
+++ b/upass/__main__.py
@@ -187,6 +187,10 @@ class App(object):
         self.box._app = self
 
         self.home = os.environ.get('PASSWORD_STORE_DIR', os.path.expanduser('~/.password-store'))
+        if not os.path.exists(self.home):
+            self.home = os.path.join(os.environ.get(
+                'XDG_DATA_HOME', '~/.local/share'), 'password-store')
+
         if os.path.exists(self.home) and os.listdir(self.home):
             self.refresh()
             self.current = '.'


### PR DESCRIPTION
Hi, 
there has been discussion on the pass mailing list to add support for the [XDG Base Directory specification](https://lists.zx2c4.com/pipermail/password-store/2020-May/004102.html), some were concerne it could break third party clients so this PR adds the functionality in a backwards compatible way following [this logic](https://lists.zx2c4.com/pipermail/password-store/2020-May/004073.html):
```
	If PASSWORD_STORE_DIR is set use that
	else if ~/.password_store exists use that
	else fallback to the XDG dir behaviour
```
I have done some basic testing and it works without issue on my system where my password store is in ~/.local/share/password-store :+1: 

Thank you for your time