### PR TITLE
Replace deprecated pkg_resources usage

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,21 +21,9 @@ setup(name='upass',
       # http://pypi.python.org/pypi?%3Aaction=list_classifiers
       classifiers=['Development Status :: 3 - Alpha',
                    'Programming Language :: Python',
-                   'Programming Language :: Python :: 2',
-                   'Programming Language :: Python :: 2.7',
-                   'Programming Language :: Python :: 3',
-                   'Programming Language :: Python :: 3.3',
-                   'Programming Language :: Python :: 3.4',
-                   'Programming Language :: Python :: 3.5',
-                   'Programming Language :: Python :: 3.6',
-                   'Programming Language :: Python :: 3.7',
-                   'Programming Language :: Python :: 3.8',
                    'Programming Language :: Python :: 3.9'],
       packages=['upass'],
       install_requires=dependencies,
-      extras_require={
-            ':python_version == "2.7"': ['configparser']
-      },
       entry_points={
           'console_scripts': [
               'upass = upass.__main__:main',

--- a/upass/__init__.py
+++ b/upass/__init__.py
@@ -40,7 +40,7 @@ Console UI for pass.
 """
 
 import os
-import pkg_resources
+import importlib.resources
 import configparser
 import argparse
 
@@ -77,15 +77,19 @@ if not os.path.exists(kwdir):
 if not os.path.exists(confdir):
     os.mkdir(confdir)
 
+ini_skel = (
+    importlib.resources.files('upass')
+    .joinpath('data/upass.ini.skel')
+    .read_text(encoding='utf-8')
+)
+
 if not os.path.exists(confpath):
     print("upass.ini does not exist, creating")
-    with open(confpath, 'wb') as fh:
-        fh.write(pkg_resources.resource_string(
-            'upass', 'data/upass.ini.skel'))
+    with open(confpath, 'w', encoding='utf-8') as fh:
+        fh.write(ini_skel)
     print("created " + confpath)
 
 # Configuration file support
 config = configparser.ConfigParser()
-config.read_string(pkg_resources.resource_string(
-            'upass', 'data/upass.ini.skel').decode('utf-8'))
+config.read_string(ini_skel)
 config.read([confpath], encoding='utf-8')


### PR DESCRIPTION
Use the `importlib.resources.files()` API, introduced in Python 3.9, in preference to the deprecated `pkg_resources`.